### PR TITLE
CIF-326 - Add missing cause for exceptions

### DIFF
--- a/src/shared/exception.js
+++ b/src/shared/exception.js
@@ -76,7 +76,7 @@ class UnexpectedError extends BaseCcifError {
  */
 class InvalidArgumentError extends BaseCcifError {
     constructor(message) {
-        super(message, 'invalid-argument', 'InvalidArgumentError');
+        super(message, { message: 'invalid-argument' }, 'InvalidArgumentError');
     }
 }
 
@@ -85,7 +85,7 @@ class InvalidArgumentError extends BaseCcifError {
  */
 class MissingPropertyError extends BaseCcifError {
     constructor(message) {
-        super(message, 'missing-property', 'MissingPropertyError');
+        super(message, { message: 'missing-property' }, 'MissingPropertyError');
     }
 }
 
@@ -94,7 +94,7 @@ class MissingPropertyError extends BaseCcifError {
  */
 class NotImplementedError extends BaseCcifError {
     constructor(message) {
-        super(message, 'not-implemented', 'NotImplementedError');
+        super(message, { message: 'not-implemented' }, 'NotImplementedError');
     }
 }
 

--- a/src/shared/exception.js
+++ b/src/shared/exception.js
@@ -75,8 +75,8 @@ class UnexpectedError extends BaseCcifError {
  * Error returned when the value for a user facing parameter did not respect the format.
  */
 class InvalidArgumentError extends BaseCcifError {
-    constructor(message, cause) {
-        super(message, cause, 'InvalidArgumentError');
+    constructor(message) {
+        super(message, 'invalid-argument', 'InvalidArgumentError');
     }
 }
 
@@ -84,8 +84,8 @@ class InvalidArgumentError extends BaseCcifError {
  * Error returned when a mandatory input parameter is missing.
  */
 class MissingPropertyError extends BaseCcifError {
-    constructor(message, cause) {
-        super(message, cause, 'MissingPropertyError');
+    constructor(message) {
+        super(message, 'missing-property', 'MissingPropertyError');
     }
 }
 
@@ -93,8 +93,8 @@ class MissingPropertyError extends BaseCcifError {
  * Error returned when an action is not implemented.
  */
 class NotImplementedError extends BaseCcifError {
-    constructor(message, cause) {
-        super(message, cause, 'NotImplementedError');
+    constructor(message) {
+        super(message, 'not-implemented', 'NotImplementedError');
     }
 }
 


### PR DESCRIPTION
* Exceptions that are thrown from our implementation, don't set the cause which usually contains the error message from errors returned from commerce backends
* The cause is a required field according to https://github.com/adobe/commerce-cif-api/pull/16