### PR TITLE
CIF-271 - Migrate Docker Repository into commerce-cif-common

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,15 @@ jobs:
 
   build-ci-image:
     working_directory: /app
-      docker:
-        - image: docker:17.09.0-ce-git
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run:
-            name: Build Docker image
-            command: |
-              docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
+    docker:
+      - image: docker:17.09.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
 
   push-ci-image-latest:
     working_directory: /app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
           path: test/results
       - store_artifacts:
           path: test/results
+
   release:
     docker:
       - image: adobe/commerce-cif-ci-env:v0.0.1
@@ -20,6 +21,52 @@ jobs:
       - run:
           name: Release
           command: node ci/release.js
+
+  build-ci-image:
+    working_directory: /app
+      docker:
+        - image: docker:17.09.0-ce-git
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run:
+            name: Build Docker image
+            command: |
+              docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
+
+  push-ci-image-latest:
+    working_directory: /app
+    docker:
+      - image: docker:17.09.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image (Latest)
+          command: |
+            docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
+      - run:
+          name: Push image to Docker Hub
+          command: |
+            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+            docker push adobe/commerce-cif-ci-env:latest
+
+  push-ci-image-tag:
+    working_directory: /app
+    docker:
+      - image: docker:17.09.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image (Tag)
+          command: |
+            docker build -t adobe/commerce-cif-ci-env:$CIRCLE_TAG ./ci/environment
+      - run:
+          name: Push image to Docker Hub
+          command: |
+            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+            docker push adobe/commerce-cif-ci-env:$CIRCLE_TAG
 
 workflows:
   version: 2
@@ -36,4 +83,25 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^@(.+)@release-(major|minor|patch)$/ 
+              only: /^@(.+)@release-(major|minor|patch)$/
+
+  build-and-push-ci-image:
+    jobs:
+      - build-ci-image:
+          filters:
+            tags:
+              only: /.*/
+      - push-ci-image-latest:
+          requires:
+            - build-ci-image
+          filters:
+            branches:
+              only: master
+      - push-ci-image-tag:
+          requires:
+            - build-ci-image
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^ci-v.*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,16 @@
+docker-build: &docker-build
+  run:
+    name: Build Docker image (Tag)
+    command: |
+      docker build -t adobe/commerce-cif-ci-env:$TAG ./ci/environment
+
+docker-push: &docker-push
+  run:
+    name: Push image to Docker Hub
+    command: |
+      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      docker push adobe/commerce-cif-ci-env:$TAG
+
 version: 2
 jobs:
   build:
@@ -26,47 +39,36 @@ jobs:
     working_directory: /app
     docker:
       - image: docker:17.09.0-ce-git
+    environment:
+       TAG: latest
     steps:
       - checkout
       - setup_remote_docker
-      - run:
-          name: Build Docker image
-          command: |
-            docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
+      - *docker-build
 
   push-ci-image-latest:
     working_directory: /app
     docker:
       - image: docker:17.09.0-ce-git
+    environment:
+       TAG: latest
     steps:
       - checkout
       - setup_remote_docker
-      - run:
-          name: Build Docker image (Latest)
-          command: |
-            docker build -t adobe/commerce-cif-ci-env:latest ./ci/environment
-      - run:
-          name: Push image to Docker Hub
-          command: |
-            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-            docker push adobe/commerce-cif-ci-env:latest
+      - *docker-build
+      - *docker-push
 
   push-ci-image-tag:
     working_directory: /app
     docker:
       - image: docker:17.09.0-ce-git
+    environment:
+       TAG: $CIRCLE_TAG
     steps:
       - checkout
       - setup_remote_docker
-      - run:
-          name: Build Docker image (Tag)
-          command: |
-            docker build -t adobe/commerce-cif-ci-env:$CIRCLE_TAG ./ci/environment
-      - run:
-          name: Push image to Docker Hub
-          command: |
-            docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-            docker push adobe/commerce-cif-ci-env:$CIRCLE_TAG
+      - *docker-build
+      - *docker-push
 
 workflows:
   version: 2

--- a/ci/environment/Dockerfile
+++ b/ci/environment/Dockerfile
@@ -1,0 +1,39 @@
+################################################################################
+#
+#    Copyright 2018 Adobe. All rights reserved.
+#    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License. You may obtain a copy
+#    of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software distributed under
+#    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+#    OF ANY KIND, either express or implied. See the License for the specific language
+#    governing permissions and limitations under the License.
+#
+################################################################################
+
+FROM circleci/openjdk:8-jdk-node
+
+LABEL maintainer="Adobe"
+
+ENV SONAR_SCANNER_VERSION=3.0.3.778-linux
+
+WORKDIR /home/circleci
+
+# Install wsk
+RUN mkdir bin && \
+    cd bin && \
+    wget -nv https://openwhisk.ng.bluemix.net/cli/go/download/linux/amd64/OpenWhisk_CLI-linux.tgz && \
+    tar -xvzf OpenWhisk_CLI-linux.tgz && \
+    rm OpenWhisk_CLI-linux.tgz && \
+    chmod +x wsk
+
+# Install sonar scanner
+RUN cd bin && \
+    wget -nv https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
+    unzip -q sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
+    rm sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
+    mv sonar-scanner-${SONAR_SCANNER_VERSION} sonar-scanner && \
+    chmod +x sonar-scanner/bin/sonar-scanner
+
+ENV PATH="${PATH}:/home/circleci/bin:/home/circleci/bin/sonar-scanner/bin"

--- a/ci/environment/README.md
+++ b/ci/environment/README.md
@@ -1,0 +1,10 @@
+# Docker CI Environment for Adobe CIF
+[![Docker Pulls](https://img.shields.io/docker/pulls/adobe/commerce-cif-ci-env.svg)](https://hub.docker.com/r/adobe/commerce-cif-ci-env/)
+
+## Introduction
+This image is based on `circleci/openjdk:8-jdk-node` and contains the following tools:
+
+* Java 8 incl. Maven
+* Node 8 incl. NPM
+* OpenWhisk CLI (WSK)
+* SonarScanner


### PR DESCRIPTION
* CI image is built for every commit to validate nothing is broken
* `latest` version of the image is built and pushed for every commit on master
* a tagged version of the image is built for every tagged commit in the format `^ci-v.*$` (e.g. `ci-v1.0.0`)