### PR TITLE
CIF-418 CIF webActionTransformer should stop base64 encoding body responses

### DIFF
--- a/src/web-action-transformer/http-response.js
+++ b/src/web-action-transformer/http-response.js
@@ -59,7 +59,7 @@ class HttpResponse {
 
     setBody(body) {
         if (body) {
-            this.body = new Buffer(JSON.stringify(body)).toString('base64');
+            this.body = JSON.stringify(body);
         }
     }
 

--- a/test/web-action-transformer/webActionTransformerTest.js
+++ b/test/web-action-transformer/webActionTransformerTest.js
@@ -46,7 +46,7 @@ describe('webActionTransformer', () => {
 
             it('Constructor with body', () => {
                 const httpResponse = new HttpResponse({'response': 'yes'});
-                assert.strictEqual(httpResponse.body, 'eyJyZXNwb25zZSI6InllcyJ9');
+                assert.strictEqual(httpResponse.body, JSON.stringify({'response': 'yes'}));
                 assert.strictEqual(httpResponse.statusCode, 200);
             });
 
@@ -64,9 +64,9 @@ describe('webActionTransformer', () => {
 
             it('set body', () => {
                 const httpResponse = new HttpResponse({'response': 'yes'});
-                assert.strictEqual(httpResponse.body, 'eyJyZXNwb25zZSI6InllcyJ9');
+                assert.strictEqual(httpResponse.body, JSON.stringify({'response': 'yes'}));
                 httpResponse.setBody({'response': 'no'});
-                assert.strictEqual(httpResponse.body, 'eyJyZXNwb25zZSI6Im5vIn0=');
+                assert.strictEqual(httpResponse.body, JSON.stringify({'response': 'no'}));
             });
 
             it('toJson', () => {
@@ -183,7 +183,7 @@ describe('webActionTransformer', () => {
 
                 // Asert
                 assert.isDefined(response);
-                assert.strictEqual(response.body, 'eyJmcm9tLXRyYW5zZm9ybWVyIjoieWVzIn0=');
+                assert.strictEqual(response.body, JSON.stringify({'from-transformer': 'yes'}));
                 assert.strictEqual(response.statusCode, 207);
                 assert.strictEqual(response.headers['something-else'], 'I am here');
                 assert.strictEqual(response.headers['something'], 'First header');
@@ -226,7 +226,7 @@ describe('webActionTransformer', () => {
                     httpResponse.error = {'name': errorName, 'cause': {'message': 'error'}};
                     transformerAction.transform(httpResponse, {});
                     assert.strictEqual(httpResponse.statusCode, errorNameToStatusCodeMap[errorName]);
-                    let body = JSON.parse(new Buffer(httpResponse.body, 'base64'));
+                    let body = JSON.parse(httpResponse.body);
                     assert.equal(body.reason, 'error');
                     if (errorName === 'SomethingThatIsNotMapped') {
                         assert.isTrue(body.message.startsWith('UnexpectedError'));
@@ -247,8 +247,7 @@ describe('webActionTransformer', () => {
 
                 transformerAction.transform(httpResponse, fromOw);
 
-                // Decode base64 from response body and parse it as JSON.
-                const responseBody = JSON.parse(Buffer.from(httpResponse.body, 'base64').toString());
+                const responseBody = JSON.parse(httpResponse.body);
                 assert.strictEqual(responseBody.type, 'sample-error-type');
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Because of https://github.com/apache/incubator-openwhisk/pull/3919 the body of JSON web action response must no longer be base64 encoded. This change is not backwards compatible, so https://github.com/apache/incubator-openwhisk/pull/3973 partially reverted that change but base64 encoded body responses are going to be deprecated.

**Please merge this PR only after Adobe I/O Runtime was updated to the corresponding OpenWhisk version.**

<!--- Describe your changes in detail -->

## Related Issue

CIF-418

## How Has This Been Tested?
Unit tests were adapted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
