### PR TITLE
CIF-476 - Introduce HTTP Vary header for cached CIF responses

### DIFF
--- a/src/web-action-transformer/caching-headers-transformer.js
+++ b/src/web-action-transformer/caching-headers-transformer.js
@@ -35,6 +35,13 @@ class CachingHeadersTransformerPipelineAction extends ITransformerPipelineAction
                     httpResponse.headers['Expires'] =
                         new Date(Date.now() + resultFromOwSequence.cachetime * 1000).toUTCString();
                 }
+
+                if (resultFromOwSequence.vary) {
+                    httpResponse.headers['Vary'] = resultFromOwSequence.vary;
+                } else {
+                    httpResponse.headers['Vary'] = 'Accept-Language';
+                }
+
                 break;
             }
             case HttpStatusCodes.NOT_FOUND: {

--- a/src/web-action-transformer/http-response.js
+++ b/src/web-action-transformer/http-response.js
@@ -59,7 +59,7 @@ class HttpResponse {
 
     setBody(body) {
         if (body) {
-            this.body = new Buffer(JSON.stringify(body)).toString('base64');
+            this.body = Buffer.from(JSON.stringify(body)).toString('base64');
         }
     }
 

--- a/test/web-action-transformer/webActionTransformerIT.js
+++ b/test/web-action-transformer/webActionTransformerIT.js
@@ -48,7 +48,7 @@ describe('web action transformer integration tests', function() {
                 assert.isDefined(response.headers['Perf-Ow-Seq-In-']);
                 assert.isDefined(response.headers['Perf-Ow-Seq-End-12345']);
                 assert.isDefined(response.body);
-            })
+            });
         });
 
         it('web action transformer error', function() {
@@ -58,8 +58,15 @@ describe('web action transformer integration tests', function() {
                 assert.strictEqual(response.statusCode, 404);
                 assert.strictEqual(response.headers['Cache-Control'], 'no-cache, no-store, no-transform, must-revalidate');
                 assert.isDefined(response.body);
-            })
+            });
         });
 
+        it('sets the Vary header', () => {
+            const actionName = `${env.actionPrefix}/main`;
+            const params = sampleCommerceServiceSuccess;
+            return ow.actions.invoke({actionName, blocking, result, params}).then(response => {
+                assert.strictEqual(response.headers['Vary'], 'Accept-Language');
+            });
+        });
     });
 });

--- a/test/web-action-transformer/webActionTransformerTest.js
+++ b/test/web-action-transformer/webActionTransformerTest.js
@@ -275,7 +275,7 @@ describe('webActionTransformer', () => {
                 assert.isTrue(Math.abs(actualExpires - expectedExpires) < 1000);
             });
 
-            it('sets vary header when there is non set from a previous action', () => {
+            it('sets vary header when there is none set from a previous action', () => {
                 const httpResponse = new HttpResponse({});
                 transformAction.transform(httpResponse, {});
                 assert.strictEqual(httpResponse.headers['Vary'], 'Accept-Language');

--- a/test/web-action-transformer/webActionTransformerTest.js
+++ b/test/web-action-transformer/webActionTransformerTest.js
@@ -226,7 +226,7 @@ describe('webActionTransformer', () => {
                     httpResponse.error = {'name': errorName, 'cause': {'message': 'error'}};
                     transformerAction.transform(httpResponse, {});
                     assert.strictEqual(httpResponse.statusCode, errorNameToStatusCodeMap[errorName]);
-                    let body = JSON.parse(new Buffer(httpResponse.body, 'base64'));
+                    let body = JSON.parse(Buffer.from(httpResponse.body, 'base64'));
                     assert.equal(body.reason, 'error');
                     if (errorName === 'SomethingThatIsNotMapped') {
                         assert.isTrue(body.message.startsWith('UnexpectedError'));
@@ -273,6 +273,19 @@ describe('webActionTransformer', () => {
                 const expectedExpires = new Date(Date.now() + 111000).getTime();
                 const actualExpires = Date.parse(httpResponse.headers['Expires']);
                 assert.isTrue(Math.abs(actualExpires - expectedExpires) < 1000);
+            });
+
+            it('sets vary header when there is non set from a previous action', () => {
+                const httpResponse = new HttpResponse({});
+                transformAction.transform(httpResponse, {});
+                assert.strictEqual(httpResponse.headers['Vary'], 'Accept-Language');
+            });
+
+            it('copies the vary header from a previous action', () => {
+                const httpResponse = new HttpResponse({});
+                const fromOw = {'vary': 'I am here'};
+                transformAction.transform(httpResponse, fromOw);
+                assert.strictEqual(httpResponse.headers['Vary'], 'I am here');
             });
 
             it('http status code NOT FOUND', () => {


### PR DESCRIPTION
Instruct caches to consider the `Accept-Language` header when caching responses.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The response of actions is dependant on the `Accept-Language` header but the caching mechanism does not take the header into account. This means that for responses from cache, you don't get the language you asked for, but the one which was cached.
This PR introduces some changes to set the `Vary` header on the HTTP responses and instruct caches that they should take the `Accept-Language` header into account.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CIF-476

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
At the moment, we might return cached responses in a different language than the one requested. This change fixes that problem.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Wrote unit and integration tests.
* Manually deployed and testes that the header is present in the response.

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
